### PR TITLE
add removeAllControllers method

### DIFF
--- a/DRWindows/DRWindows/DRWindows/DRWindowController.h
+++ b/DRWindows/DRWindows/DRWindows/DRWindowController.h
@@ -21,5 +21,6 @@ typedef void (^DRWindowCompletionBlock)();
 // Removing views
 - (void)removeWindowView:(UIView *)view;
 - (void)removeWindowController:(UIViewController *)controller;
+- (void)removeAllControllers;
 
 @end

--- a/DRWindows/DRWindows/DRWindows/DRWindowController.m
+++ b/DRWindows/DRWindows/DRWindows/DRWindowController.m
@@ -121,6 +121,21 @@
     }
 }
 
+- (void)removeAllControllers {
+    
+    // remove completionHandlers
+    self.completionHandlers = [NSMutableSet new];
+    
+    // remove controllers
+    NSSet *controllersToRemove = [self.controllers copy];
+    
+    [controllersToRemove enumerateObjectsUsingBlock:^(id obj, BOOL *stop) {
+        NSParameterAssert([obj isKindOfClass:[UIViewController class]]);
+        [self removeWindowController:obj];
+    }];
+    
+}
+
 #pragma mark - Private
 
 - (void)_addCompletionHandler:(DRWindowCompletionBlock)handler forController:(UIViewController *)controller


### PR DESCRIPTION
(also clears completion blocks)

in our project, this was needed on 'sign out' - to completely clear all of the UI hierarchy (and then reload it from scratch)
